### PR TITLE
Fix zsh completion error

### DIFF
--- a/keybase
+++ b/keybase
@@ -5,7 +5,7 @@ function _keybase() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    prevs=("${COMP_WORDS[@]:1:COMP_CWORD-1}")
+    prevs=("${COMP_WORDS[@]:1:$COMP_CWORD-1}")
     lprev=${#prevs[@]}
 
     # Will try to keep args and their cases sorted alphabetically -jhazelwo


### PR DESCRIPTION
Bash treats "${COMP_WORDS[@]:0:COMP_CWORD}" and "${COMP_WORDS[@]:0:$COMP_CWORD}" the same, but Zsh used with `bashcompinit` only accepts the latter. So this commit maintains the same compatibility with Bash while improving it with Zsh.